### PR TITLE
Fix ReturnToRoost dragon AI

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/DragonUtils.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/DragonUtils.java
@@ -19,6 +19,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.EntitySelectors;
 import net.minecraft.util.math.*;
 import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -48,7 +49,8 @@ public class DragonUtils {
             BlockPos ground = dragon.world.getHeight(dragonPos);
             int distFromGround = (int) dragon.posY - ground.getY();
             for (int i = 0; i < 10; i++) {
-                BlockPos pos = new BlockPos(dragon.homePos.getX() + dragon.getRNG().nextInt(IceAndFire.CONFIG.dragonWanderFromHomeDistance * 2) - IceAndFire.CONFIG.dragonWanderFromHomeDistance, (distFromGround > 16 ? (int) Math.min(IceAndFire.CONFIG.maxDragonFlight, dragon.posY + dragon.getRNG().nextInt(16) - 8) : (int) dragon.posY + dragon.getRNG().nextInt(16) + 1), (dragon.homePos.getZ() + dragon.getRNG().nextInt(IceAndFire.CONFIG.dragonWanderFromHomeDistance * 2) - IceAndFire.CONFIG.dragonWanderFromHomeDistance));
+                BlockPos homePos = dragon.homePos.getPosition();
+                BlockPos pos = new BlockPos(homePos.getX() + dragon.getRNG().nextInt(IceAndFire.CONFIG.dragonWanderFromHomeDistance * 2) - IceAndFire.CONFIG.dragonWanderFromHomeDistance, (distFromGround > 16 ? (int) Math.min(IceAndFire.CONFIG.maxDragonFlight, dragon.posY + dragon.getRNG().nextInt(16) - 8) : (int) dragon.posY + dragon.getRNG().nextInt(16) + 1), (homePos.getZ() + dragon.getRNG().nextInt(IceAndFire.CONFIG.dragonWanderFromHomeDistance * 2) - IceAndFire.CONFIG.dragonWanderFromHomeDistance));
                 if (!dragon.isTargetBlocked(new Vec3d(pos)) && dragon.getDistanceSqToCenter(pos) > 6) {
                     return pos;
                 }
@@ -256,6 +258,14 @@ public class DragonUtils {
                 || className.contains("Rabbit") || className.contains("Peacock") || className.contains("Goat") || className.contains("Ferret")
                 || className.contains("Hedgehog") || className.contains("Peahen") || className.contains("Peafowl") || className.contains("Sow")
                 || className.contains("Hog") || className.contains("Hog");
+    }
+
+    public static int getDimensionID(World world) {
+        return world.provider.getDimension();
+    }
+
+    public static boolean isInHomeDimension(EntityDragonBase dragonBase) {
+        return (dragonBase.getHomeDimensionID() == null || getDimensionID(dragonBase.world) == (dragonBase.getHomeDimensionID()));
     }
 
     public static boolean canDragonBreak(Block block) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -162,7 +162,7 @@ public abstract class EntityDragonBase extends EntityTameable implements ISyncMo
     public int swimCycle;
     public boolean isDaytime;
     public int flightCycle;
-    public BlockPos homePos;
+    public HomePosition homePos;
     public boolean hasHomePosition = false;
     @SideOnly(Side.CLIENT)
     public IFChainBuffer roll_buffer;
@@ -250,6 +250,15 @@ public abstract class EntityDragonBase extends EntityTameable implements ISyncMo
         switchNavigator(0);
         randomizeAttacks();
         resetParts(1);
+    }
+
+    @Override
+    public BlockPos getHomePosition() {
+        return this.homePos == null ? super.getHomePosition() : this.homePos.getPosition();
+    }
+
+    public Integer getHomeDimensionID() {
+        return this.homePos == null ? null : this.homePos.getDimension();
     }
 
     @Override
@@ -633,9 +642,7 @@ public abstract class EntityDragonBase extends EntityTameable implements ISyncMo
         compound.setBoolean("Tackle", this.isTackling());
         compound.setBoolean("HasHomePosition", this.hasHomePosition);
         if (homePos != null && this.hasHomePosition) {
-            compound.setInteger("HomeAreaX", homePos.getX());
-            compound.setInteger("HomeAreaY", homePos.getY());
-            compound.setInteger("HomeAreaZ", homePos.getZ());
+            homePos.write(compound);
         }
         compound.setBoolean("AgingDisabled", this.isAgingDisabled());
         compound.setInteger("Command", this.getCommand());
@@ -676,7 +683,7 @@ public abstract class EntityDragonBase extends EntityTameable implements ISyncMo
         }
         this.hasHomePosition = compound.getBoolean("HasHomePosition");
         if (hasHomePosition && compound.getInteger("HomeAreaX") != 0 && compound.getInteger("HomeAreaY") != 0 && compound.getInteger("HomeAreaZ") != 0) {
-            homePos = new BlockPos(compound.getInteger("HomeAreaX"), compound.getInteger("HomeAreaY"), compound.getInteger("HomeAreaZ"));
+            homePos = new HomePosition(compound, this.world);
         }
         this.setTackling(compound.getBoolean("Tackle"));
         this.setAgingDisabled(compound.getBoolean("AgingDisabled"));
@@ -1106,9 +1113,10 @@ public abstract class EntityDragonBase extends EntityTameable implements ISyncMo
                                 this.hasHomePosition = false;
                                 player.sendStatusMessage(new TextComponentTranslation("dragon.command.remove_home"), true);
                             } else {
-                                this.homePos = new BlockPos(this);
+                                BlockPos pos = this.getPosition();
+                                this.homePos = new HomePosition(pos, this.world);
                                 this.hasHomePosition = true;
-                                player.sendStatusMessage(new TextComponentTranslation("dragon.command.new_home", homePos.getX(), homePos.getY(), homePos.getZ()), true);
+                                player.sendStatusMessage(new TextComponentTranslation("dragon.command.new_home", pos.getX(), pos.getY(), pos.getZ()), true);
                             }
                             return true;
                         } else {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/HomePosition.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/HomePosition.java
@@ -1,0 +1,67 @@
+package com.github.alexthe666.iceandfire.entity;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class HomePosition {
+    private int x;
+    private int y;
+    private int z;
+    private BlockPos pos;
+    private Integer dimension;
+
+    public HomePosition(NBTTagCompound compound) {
+        read(compound);
+    }
+
+    public HomePosition(NBTTagCompound compound, World world) {
+        read(compound, world);
+    }
+
+    public HomePosition(BlockPos pos, World world) {
+        this(pos.getX(), pos.getY(), pos.getZ(), world);
+    }
+
+    public HomePosition(int x, int y, int z, World world) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        pos = new BlockPos(x, y, z);
+        this.dimension = DragonUtils.getDimensionID(world);
+    }
+
+    public BlockPos getPosition() {
+        return pos;
+    }
+
+    public Integer getDimension() {
+        return dimension;
+    }
+
+    public void write(NBTTagCompound compound) {
+        compound.setInteger("HomeAreaX", this.x);
+        compound.setInteger("HomeAreaY", this.y);
+        compound.setInteger("HomeAreaZ", this.z);
+        if (dimension != null)
+            compound.setInteger("HomeDimension", this.dimension);
+    }
+
+    public void read(NBTTagCompound compound, World world) {
+        read(compound);
+        if (this.dimension == null)
+            this.dimension = DragonUtils.getDimensionID(world);
+    }
+
+    public void read(NBTTagCompound compound) {
+        if (compound.hasKey("HomeAreaX"))
+            this.x = compound.getInteger("HomeAreaX");
+        if (compound.hasKey("HomeAreaY"))
+            this.y = compound.getInteger("HomeAreaY");
+        if (compound.hasKey("HomeAreaZ"))
+            this.z = compound.getInteger("HomeAreaZ");
+        pos = new BlockPos(x, y, z);
+        if (compound.hasKey("HomeDimension"))
+            this.dimension = compound.getInteger("HomeDimension");
+    }
+}

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/IafDragonLogic.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/IafDragonLogic.java
@@ -128,7 +128,11 @@ public class IafDragonLogic {
             dragon.lookingForRoostAIFlag = false;
         }
         if (IceAndFire.CONFIG.doDragonsSleep && !dragon.isSleeping() && !dragon.isDaytime() && dragon.getPassengers().isEmpty()) {
-            if(dragon.hasHomePosition && dragon.getHomePosition() != null && dragon.getDistanceSquared(IAFMath.copyCentered(dragon.getHomePosition())) > dragon.width * 10){
+            if (dragon.hasHomePosition
+                && dragon.getHomePosition() != null
+                && DragonUtils.isInHomeDimension(dragon)
+                && dragon.getDistanceSquared(IAFMath.copyCentered(dragon.getHomePosition())) > dragon.width * 10
+                && dragon.getCommand() != 2 && dragon.getCommand() != 1){
                 dragon.lookingForRoostAIFlag = true;
             }else{
                 dragon.lookingForRoostAIFlag = false;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAIReturnToRoost.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAIReturnToRoost.java
@@ -1,5 +1,6 @@
 package com.github.alexthe666.iceandfire.entity.ai;
 
+import com.github.alexthe666.iceandfire.entity.DragonUtils;
 import com.github.alexthe666.iceandfire.entity.EntityDragonBase;
 import com.github.alexthe666.iceandfire.util.IAFMath;
 
@@ -14,12 +15,19 @@ public class DragonAIReturnToRoost extends EntityAIBase {
 
 	@Override
 	public boolean shouldExecute() {
-		return this.dragon.canMove() && this.dragon.lookingForRoostAIFlag && (dragon.getAttackTarget() == null || !dragon.getAttackTarget().isEntityAlive()) && dragon.getDistanceSquared(IAFMath.copyCentered(dragon.getHomePosition())) > dragon.width * dragon.width;
+		return this.dragon.canMove() && this.dragon.lookingForRoostAIFlag
+            && (dragon.getAttackTarget() == null || !dragon.getAttackTarget().isEntityAlive())
+            && dragon.getHomePosition() != null
+            && DragonUtils.isInHomeDimension(dragon)
+            && dragon.getDistanceSquared(IAFMath.copyCentered(dragon.getHomePosition())) > dragon.width * dragon.width;
 	}
 	
     @Override
     public void updateTask() {
-        this.dragon.getHomePosition();
+        if (this.dragon.getHomePosition() == null) {
+            return;
+        }
+
         double dist = Math.sqrt(dragon.getDistanceSquared(IAFMath.copyCentered(dragon.getHomePosition())));
         double xDist = Math.abs(dragon.posX - dragon.getHomePosition().getX() - 0.5F);
         double zDist = Math.abs(dragon.posZ - dragon.getHomePosition().getZ() - 0.5F);

--- a/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenFireDragonCave.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenFireDragonCave.java
@@ -4,6 +4,8 @@ import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.block.BlockGoldPile;
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
 import com.github.alexthe666.iceandfire.entity.EntityFireDragon;
+import com.github.alexthe666.iceandfire.entity.HomePosition;
+
 import net.minecraft.block.BlockChest;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
@@ -71,7 +73,7 @@ public class WorldGenFireDragonCave extends WorldGenerator {
         dragon.setVariant(rand.nextInt(4));
         dragon.setPositionAndRotation(position.getX() + 0.5, position.getY() + 0.5, position.getZ() + 0.5, rand.nextFloat() * 360, 0);
         dragon.setSleeping(true);
-        dragon.homePos = position;
+        dragon.homePos = new HomePosition(position, worldIn);
         dragon.setHunger(50);
         worldIn.spawnEntity(dragon);
         return false;

--- a/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenFireDragonRoosts.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenFireDragonRoosts.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.iceandfire.world.gen;
 
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
 import com.github.alexthe666.iceandfire.entity.EntityFireDragon;
+import com.github.alexthe666.iceandfire.entity.HomePosition;
 import com.github.alexthe666.iceandfire.event.WorldGenEvents;
 import net.minecraft.block.BlockChest;
 import net.minecraft.block.BlockContainer;
@@ -117,7 +118,7 @@ public class WorldGenFireDragonRoosts extends WorldGenerator {
             dragon.setHealth(dragon.getMaxHealth());
             dragon.setVariant(new Random().nextInt(4));
             dragon.setPositionAndRotation(position.getX() + 0.5, worldIn.getHeight(position).getY() + 1.5, position.getZ() + 0.5, rand.nextFloat() * 360, 0);
-            dragon.homePos = position;
+            dragon.homePos = new HomePosition(position, worldIn);
             dragon.hasHomePosition = true;
             dragon.setHunger(50);
             worldIn.spawnEntity(dragon);

--- a/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenIceDragonCave.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenIceDragonCave.java
@@ -4,6 +4,8 @@ import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.block.BlockSilverPile;
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
 import com.github.alexthe666.iceandfire.entity.EntityIceDragon;
+import com.github.alexthe666.iceandfire.entity.HomePosition;
+
 import net.minecraft.block.BlockChest;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
@@ -71,7 +73,7 @@ public class WorldGenIceDragonCave extends WorldGenerator {
         dragon.setVariant(rand.nextInt(4));
         dragon.setPositionAndRotation(position.getX() + 0.5, position.getY() + 0.5, position.getZ() + 0.5, rand.nextFloat() * 360, 0);
         dragon.setSleeping(true);
-        dragon.homePos = position;
+        dragon.homePos = new HomePosition(position, worldIn);
         dragon.setHunger(50);
         worldIn.spawnEntity(dragon);
         return false;

--- a/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenIceDragonRoosts.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenIceDragonRoosts.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.iceandfire.world.gen;
 
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
 import com.github.alexthe666.iceandfire.entity.EntityIceDragon;
+import com.github.alexthe666.iceandfire.entity.HomePosition;
 import com.github.alexthe666.iceandfire.event.WorldGenEvents;
 import net.minecraft.block.BlockChest;
 import net.minecraft.block.BlockContainer;
@@ -117,7 +118,7 @@ public class WorldGenIceDragonRoosts extends WorldGenerator {
             dragon.setHealth(dragon.getMaxHealth());
             dragon.setVariant(new Random().nextInt(4));
             dragon.setPositionAndRotation(position.getX() + 0.5, worldIn.getHeight(position).getY() + 1.5, position.getZ() + 0.5, rand.nextFloat() * 360, 0);
-            dragon.homePos = position;
+            dragon.homePos = new HomePosition(position, worldIn);
             dragon.hasHomePosition = true;
             dragon.setHunger(50);
             worldIn.spawnEntity(dragon);

--- a/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenLightningDragonCave.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenLightningDragonCave.java
@@ -4,6 +4,7 @@ import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.block.BlockCopperPile;
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
 import com.github.alexthe666.iceandfire.entity.EntityLightningDragon;
+import com.github.alexthe666.iceandfire.entity.HomePosition;
 
 import net.minecraft.block.BlockChest;
 import net.minecraft.block.BlockContainer;
@@ -72,7 +73,7 @@ public class WorldGenLightningDragonCave extends WorldGenerator {
         dragon.setVariant(rand.nextInt(4));
         dragon.setPositionAndRotation(position.getX() + 0.5, position.getY() + 0.5, position.getZ() + 0.5, rand.nextFloat() * 360, 0);
         dragon.setSleeping(true);
-        dragon.homePos = position;
+        dragon.homePos = new HomePosition(position, worldIn);
         dragon.setHunger(50);
         worldIn.spawnEntity(dragon);
         return false;

--- a/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenLightningDragonRoosts.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/gen/WorldGenLightningDragonRoosts.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.iceandfire.world.gen;
 
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
 import com.github.alexthe666.iceandfire.entity.EntityLightningDragon;
+import com.github.alexthe666.iceandfire.entity.HomePosition;
 import com.github.alexthe666.iceandfire.event.WorldGenEvents;
 
 import net.minecraft.block.BlockChest;
@@ -118,7 +119,7 @@ public class WorldGenLightningDragonRoosts extends WorldGenerator {
             dragon.setHealth(dragon.getMaxHealth());
             dragon.setVariant(new Random().nextInt(4));
             dragon.setPositionAndRotation(position.getX() + 0.5, worldIn.getHeight(position).getY() + 1.5, position.getZ() + 0.5, rand.nextFloat() * 360, 0);
-            dragon.homePos = position;
+            dragon.homePos = new HomePosition(position, worldIn);
             dragon.hasHomePosition = true;
             dragon.setHunger(50);
             worldIn.spawnEntity(dragon);


### PR DESCRIPTION
The class `DragonAIReturnToRoost` that was added by Mellohi as part of the lightning dragons PR was broken because any calls to `EntityDragonBase#getHomePosition()` used `EntityCreature#getHomePosition()`, which uses `EntityCreature#homePosition`. `EntityDragonBase` uses/updates its own `homePos`, not `EntityCreature#homePosition`, so an override for `getHomePosition()` is necessary.
Should fix #41 behavior for new and existing worlds.

Also backports `HomePosition` for `EntityDragonBase` because:
a) `homePos` would be redundant as the provided `EntityCreature#homePosition` should be used
b) `HomePosition` keeps track of the dragon's home dimension to handle the edge case of the dragon being in a different dimension.