### PR TITLE
Bugfixes for some reported issues

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
@@ -112,7 +112,6 @@ public class IceAndFire {
         ThaumcraftCompatBridge.loadThaumcraftCompat();
         LootFunctionManager.registerFunction(new CustomizeToDragon.Serializer());
         LootFunctionManager.registerFunction(new CustomizeToSeaSerpent.Serializer());
-        OneProbeCompatBridge.loadPreInit();
         TinkersCompatBridge.loadTinkersCompat();
         CraftTweakerCompatBridge.loadTweakerCompat();
         PROXY.preRender();
@@ -169,6 +168,7 @@ public class IceAndFire {
                 return new TextComponentString(entityLivingBaseIn.getDisplayName().getFormattedText() + " ").appendSibling(new TextComponentTranslation(s1, entityLivingBaseIn.getDisplayName()));
             }
         }.setDamageBypassesArmor();
+        OneProbeCompatBridge.loadInit();
     }
 
     @EventHandler

--- a/src/main/java/com/github/alexthe666/iceandfire/compat/OneProbeCompatBridge.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/compat/OneProbeCompatBridge.java
@@ -6,7 +6,7 @@ import net.minecraftforge.fml.common.Loader;
 public class OneProbeCompatBridge {
     private static final String COMPAT_MOD_ID = "theoneprobe";
 
-    public static void loadPreInit() {
+    public static void loadInit() {
         if (Loader.isModLoaded(COMPAT_MOD_ID)) {
             IceAndFireOneProbeCompat.register();
         }

--- a/src/main/java/com/github/alexthe666/iceandfire/compat/theoneprobe/DragonInfoProvider.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/compat/theoneprobe/DragonInfoProvider.java
@@ -5,10 +5,10 @@ import mcjty.theoneprobe.api.IProbeHitEntityData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.IProbeInfoEntityProvider;
 import mcjty.theoneprobe.api.ProbeMode;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
-import slimeknights.tconstruct.library.Util;
 
 public class DragonInfoProvider implements IProbeInfoEntityProvider {
 
@@ -23,12 +23,16 @@ public class DragonInfoProvider implements IProbeInfoEntityProvider {
             EntityDragonBase dragon = (EntityDragonBase) entity;
 
             if (dragon.isTamed() && dragon.getOwner() != null) {
-                probeInfo.horizontal().text(Util.translateFormatted("dragon.owner") + dragon.getOwner().getName());
+                probeInfo.text(localize("dragon.owner") + " " + dragon.getOwner().getName());
             } else {
-                probeInfo.horizontal().text(Util.translateFormatted("dragon.untamed"));
+                probeInfo.text(localize("dragon.untamed"));
             }
-            probeInfo.horizontal().text(Util.translateFormatted("dragon.gender") + Util.translateFormatted(dragon.isMale() ? "dragon.gender.male" : "dragon.gender.female"));
-            probeInfo.horizontal().text(Util.translateFormatted("dragon.stage") + dragon.getDragonStage());
+            probeInfo.text(localize("dragon.gender") + " " + localize(dragon.isMale() ? "dragon.gender.male" : "dragon.gender.female"));
+            probeInfo.text(localize("dragon.stage") + " " + dragon.getDragonStage());
         }
+    }
+
+    private String localize(String text) {
+        return IProbeInfo.STARTLOC + text + IProbeInfo.ENDLOC;
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/compat/theoneprobe/IceAndFireOneProbeCompat.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/compat/theoneprobe/IceAndFireOneProbeCompat.java
@@ -1,10 +1,21 @@
 package com.github.alexthe666.iceandfire.compat.theoneprobe;
 
-import mcjty.theoneprobe.TheOneProbe;
+import java.util.function.Function;
 
-public class IceAndFireOneProbeCompat {
+import net.minecraftforge.fml.common.event.FMLInterModComms;
 
+import mcjty.theoneprobe.api.ITheOneProbe;
+
+public class IceAndFireOneProbeCompat implements Function<ITheOneProbe, Void>
+{
     public static void register() {
-        TheOneProbe.theOneProbeImp.registerEntityProvider(new DragonInfoProvider());
+        FMLInterModComms.sendFunctionMessage("theoneprobe", "getTheOneProbe", IceAndFireOneProbeCompat.class.getName());
+    }
+
+    @Override
+    public Void apply(ITheOneProbe input)
+    {
+        input.registerEntityProvider(new DragonInfoProvider());
+        return null;
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityCockatrice.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityCockatrice.java
@@ -141,7 +141,7 @@ public class EntityCockatrice extends EntityTameable implements IAnimatedEntity,
     }
 
     private boolean canUseStareOn(Entity entity) {
-        return !IsImmune.toStone(entity) && (entity instanceof IBlacklistedFromStatues && ((IBlacklistedFromStatues) entity).canBeTurnedToStone()) && !ServerEvents.isAnimaniaFerret(entity);
+        return !IsImmune.toStone(entity) && (!(entity instanceof IBlacklistedFromStatues) || ((IBlacklistedFromStatues) entity).canBeTurnedToStone()) && !ServerEvents.isAnimaniaFerret(entity);
     }
 
     private void switchAI(boolean melee) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -1111,21 +1111,22 @@ public abstract class EntityDragonBase extends EntityTameable implements ISyncMo
                         if (player.isSneaking()) {
                             if (this.hasHomePosition) {
                                 this.hasHomePosition = false;
-                                player.sendStatusMessage(new TextComponentTranslation("dragon.command.remove_home"), true);
+                                if (!world.isRemote) {
+                                    player.sendStatusMessage(new TextComponentTranslation("dragon.command.remove_home"), true);
+                                }
                             } else {
                                 BlockPos pos = this.getPosition();
                                 this.homePos = new HomePosition(pos, this.world);
                                 this.hasHomePosition = true;
-                                player.sendStatusMessage(new TextComponentTranslation("dragon.command.new_home", pos.getX(), pos.getY(), pos.getZ()), true);
-                            }
-                            return true;
-                        } else {
-                            this.playSound(SoundEvents.ENTITY_ZOMBIE_INFECT, this.getSoundVolume(), this.getSoundPitch());
-                            if (!world.isRemote) {
-                                this.setCommand(this.getCommand() + 1);
-                                if (this.getCommand() > 2) {
-                                    this.setCommand(0);
+                                if (!world.isRemote) {
+                                    player.sendStatusMessage(new TextComponentTranslation("dragon.command.new_home", pos.getX(), pos.getY(), pos.getZ()), true);
                                 }
+                            }
+                        } else if (!world.isRemote){
+                            this.playSound(SoundEvents.ENTITY_ZOMBIE_INFECT, this.getSoundVolume(), this.getSoundPitch());
+                            this.setCommand(this.getCommand() + 1);
+                            if (this.getCommand() > 2) {
+                                this.setCommand(0);
                             }
                             String commandText = "stand";
                             if (this.getCommand() == 1) {
@@ -1135,8 +1136,8 @@ public abstract class EntityDragonBase extends EntityTameable implements ISyncMo
                                 commandText = "escort";
                             }
                             player.sendStatusMessage(new TextComponentTranslation("dragon.command." + commandText), true);
-                            return true;
                         }
+                        return true;
                     }
                 }
             }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -1122,7 +1122,7 @@ public abstract class EntityDragonBase extends EntityTameable implements ISyncMo
                                     player.sendStatusMessage(new TextComponentTranslation("dragon.command.new_home", pos.getX(), pos.getY(), pos.getZ()), true);
                                 }
                             }
-                        } else if (!world.isRemote){
+                        } else if (!world.isRemote) {
                             this.playSound(SoundEvents.ENTITY_ZOMBIE_INFECT, this.getSoundVolume(), this.getSoundPitch());
                             this.setCommand(this.getCommand() + 1);
                             if (this.getCommand() > 2) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexEgg.java
@@ -165,6 +165,7 @@ public class EntityMyrmexEgg extends EntityLiving implements IBlacklistedFromSta
 
     @Override
     public boolean attackEntityFrom(DamageSource dmg, float var2) {
+        if(this.isDead) return false;
         if (dmg == DamageSource.IN_WALL || dmg == DamageSource.FALL) {
             return false;
         }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixieCharge.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixieCharge.java
@@ -104,8 +104,8 @@ public class EntityPixieCharge extends EntityFireball {
                     this.entityDropItem(new ItemStack(IafItemRegistry.pixie_dust, 1), 0.45F);
                 }
             }
+            this.setDead();
         }
-        this.setDead();
     }
 
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySeaSerpent.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySeaSerpent.java
@@ -722,7 +722,7 @@ public class EntitySeaSerpent extends EntityAnimal implements IAnimatedEntity, I
         } else {
             this.setSeaSerpentScale(1.5F + this.getRNG().nextFloat() * 4.0F);
         }
-        this.heal(this.getMaxHealth());
+        this.setHealth(this.getMaxHealth());
         return livingdata;
     }
 
@@ -736,6 +736,7 @@ public class EntitySeaSerpent extends EntityAnimal implements IAnimatedEntity, I
         } else {
             this.setSeaSerpentScale(1.5F + random.nextFloat() * 4.0F);
         }
+        this.setHealth(this.getMaxHealth());
     }
 
     @Nullable


### PR DESCRIPTION
Just some quick fixes for issues reported in this repo.
- TheOneProbe info is now correctly displayed for dragons. Fixes #59.
- Using a dragon staff is now handled on the right side. Fixes #65.
- Cockatrice eye laser attack check had the wrong condition. Fixes #38.
- Fixed possible dupe with myrmex eggs. Fixes #34.
- Fixed pixie wand appearing to not fire correctly on the client side. Fixes #26.
- Fixed naturally spawned sea serpents not being at max health. Fixes #35.

Would appreciate a CurseForge release if possible! The Thaumic Additions issue that was fixed earlier would especially be nice to have fixed in a published version.